### PR TITLE
fix: correct Render service type for static site

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,8 +13,9 @@ services:
     healthCheckPath: /api/health
     
   # Frontend static site
-  - type: static
+  - type: web
     name: cheera-udaykiran
+    runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist
     plan: free


### PR DESCRIPTION
- Change from 'type: static' to 'type: web' with 'runtime: static'
- This resolves the 'unknown type static' error in Render deployment