### PR TITLE
fix: remove plan specification for static site service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,6 @@ services:
     runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist
-    plan: free
     pullRequestPreviewsEnabled: true
     headers:
       - path: /*


### PR DESCRIPTION
- Static sites on Render don't use plan designation
- Removes 'plan: free' from static site service configuration
- Resolves 'no such plan free for service type web' error